### PR TITLE
Leave <br> tags in the DOM

### DIFF
--- a/tablextract/resources/add_render.js
+++ b/tablextract/resources/add_render.js
@@ -11,6 +11,12 @@ function pathTo(element) {
 var removeElements = []
 function addRender(subtree) {
 	var style = getComputedStyle(subtree)
+	// break is often used inside cells for data item separation
+	// Example: https://secondlifestorage.com/index.php?threads/a123systems-apr18650m1a-cell-specifications.4715/
+	// See "Charging" and "Discharging" cells
+	if (subtree.tagName == 'BR') { 
+		return
+	}
 	if (subtree.tagName == 'TR' && subtree.children.length == 0 || subtree.offsetWidth == undefined || subtree.offsetHeight == undefined || subtree.offsetWidth == 0 || subtree.offsetHeight == 0 || style['display'] == 'none' || subtree.tagName == 'SUP' && subtree.className == 'reference') {
 		removeElements.push(subtree)
 		return


### PR DESCRIPTION
The code changes add_render.js to ignore <br> tags and not remove them. These tags are useful for the code as they are used inside cells to separate different data items. For example, consider the table on this site: https://secondlifestorage.com/index.php\?threads/celldata.6101/

With the original version of the package the record created from the main "Cell Specifications" table has the "Charging", "Discharging" and other cells clumped together like so:

`{'Brand:': 'Valence',
 'Capacity:': '1300mAh Rated',
 'Charging:': '3.65V Maximum650mA Standard1300mA Maximum',
 'Description:': 'Orance Cell WrapperGrey Insulator Ring18650 Form Factor',
 'Discharging:': '2.00V Cutoff260mA Standard2600mA Maximum',
 'Model:': 'IFR-18650EC',
 'Voltage:': '3.20V Nominal'}`

after the change, the <br> tags are correctly turned into spaces in the extract_text giving us:

`{'Brand:': 'Valence',
 'Capacity:': '1300mAh Rated',
 'Charging:': '3.65V Maximum 650mA Standard 1300mA Maximum',
 'Description:': 'Orance Cell Wrapper Grey Insulator Ring 18650 Form Factor',
 'Discharging:': '2.00V Cutoff 260mA Standard 2600mA Maximum',
 'Model:': 'IFR-18650EC',
 'Voltage:': '3.20V Nominal'}`