### PR TITLE
Fix setting Firefox mode to `headless`

### DIFF
--- a/tablextract/utils.py
+++ b/tablextract/utils.py
@@ -304,7 +304,7 @@ def get_driver(headless=True, disable_images=True, open_links_same_tab=False):
 		if open_links_same_tab:
 			opts.set_preference('browser.link.open_newwindow.restriction', 0)
 			opts.set_preference('browser.link.open_newwindow', 1)
-		if headless: opts.set_headless()
+		if headless: opts.headless = True
 		if disable_images: opts.set_preference('permissions.default.image', 2)
 		exec_path, log_path = find_driver_path()
 		try:


### PR DESCRIPTION
As calling `set_headless` is not deprecated (https://stackoverflow.com/questions/46753393/how-to-make-firefox-headless-programmatically-in-selenium-with-python), this commit switches to setting `opts.headless` to `True`.